### PR TITLE
Redesign around a liquid-glass material

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,30 +4,63 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-inter);
-  --font-display: var(--font-manrope);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --font-display: var(--font-jakarta);
+  --radius-sm: var(--r-sm);
+  --radius-md: var(--r-md);
+  --radius-lg: var(--r-lg);
+  --radius-xl: var(--r-xl);
 }
 
 :root {
-  --radius: 0.125rem;
+  /* ---- Radii — generous, iOS-material ---- */
+  --r-xs: 10px;
+  --r-sm: 14px;
+  --r-md: 20px;
+  --r-lg: 28px;
+  --r-xl: 36px;
+  --r-full: 999px;
 
-  /* Monochromatic Dark System */
-  --background: #0a0a0a;
-  --surface: #131313;
-  --surface-container: #151515;
-  --surface-high: #1b1b1b;
-  --surface-elevated: #2a2a2a;
-  --foreground: #e2e2e2;
-  --text-primary: #e2e2e2;
-  --text-secondary: #c6c6c6;
-  --text-muted: #919191;
-  --text-ghost: rgba(255, 255, 255, 0.1);
-  --border: rgba(255, 255, 255, 0.05);
-  --border-subtle: rgba(255, 255, 255, 0.1);
-  --border-medium: rgba(255, 255, 255, 0.2);
+  /* ---- Base field ----
+     Cooler and slightly deeper than flat black so the aura reads as light,
+     not as a stain. Everything above this is either glass or type. */
+  --background: #060608;
+  --background-deep: #030305;
+  --foreground: #f2f2f5;
+
+  --text-primary: #f4f4f7;
+  --text-secondary: #b9b9c6;
+  --text-muted: #82829a;
+  --text-faint: #55556a;
+
+  /* ---- Aura hues — the only chroma in the system ----
+     Never applied to type or UI. Only ever seen *through* glass. */
+  --aura-indigo: 99 91 255;
+  --aura-violet: 168 85 247;
+  --aura-teal: 45 212 191;
+
+  /* ---- Glass ---- */
+  --glass-blur: 28px;
+  --glass-saturate: 180%;
+  --glass-tint-hi: rgba(255, 255, 255, 0.1);
+  --glass-tint-lo: rgba(255, 255, 255, 0.022);
+  --glass-rim: rgba(255, 255, 255, 0.22);
+  --glass-rim-dim: rgba(255, 255, 255, 0.04);
+  --glass-shadow: 0 24px 70px -24px rgba(0, 0, 0, 0.85);
+
+  /* ---- Light glass (contact inversion) ---- */
+  --light-bg: #eceaf4;
+  --light-text: #16161d;
+  --light-text-muted: #5c5c72;
+  --light-tint-hi: rgba(255, 255, 255, 0.9);
+  --light-tint-lo: rgba(255, 255, 255, 0.45);
+  --light-rim: rgba(255, 255, 255, 0.95);
+  --light-shadow: 0 24px 60px -26px rgba(40, 34, 80, 0.35);
+
+  --ease-glass: cubic-bezier(0.32, 0.72, 0, 1);
+
+  /* Navbar active-item pill — overridden by .nav-on-light */
+  --nav-active-bg: rgba(255, 255, 255, 0.09);
+  --nav-active-rim: rgba(255, 255, 255, 0.18);
 }
 
 @layer base {
@@ -37,6 +70,8 @@
 
   html {
     overflow-x: clip;
+    scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
   }
 
   body {
@@ -44,124 +79,535 @@
     color: var(--foreground);
     font-family: var(--font-sans);
     overflow-x: clip;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   body[data-sheet-open] {
     overflow: hidden;
   }
+
+  ::selection {
+    background: rgb(var(--aura-violet) / 0.35);
+    color: #fff;
+  }
+
+  :focus-visible {
+    outline: 2px solid rgb(var(--aura-indigo) / 0.9);
+    outline-offset: 3px;
+    border-radius: var(--r-xs);
+  }
 }
 
 /* ============================================
-   TYPOGRAPHY
+   TYPOGRAPHY — soft reset
+   Sentence case, optical sizing, relaxed tracking.
    ============================================ */
 
 .font-display {
   font-family: var(--font-display);
+  font-optical-sizing: auto;
 }
 
 .text-display {
-  font-size: clamp(4rem, 10vw, 9rem);
+  font-family: var(--font-display);
+  font-size: clamp(3.75rem, 11vw, 10rem);
   font-weight: 800;
-  letter-spacing: -0.04em;
-  line-height: 0.85;
+  letter-spacing: -0.045em;
+  line-height: 0.88;
 }
 
 .text-section-title {
-  font-size: clamp(2.5rem, 5vw, 5rem);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  line-height: 0.9;
-}
-
-/* ============================================
-   NAVIGATION
-   ============================================ */
-
-.nav-dark {
-  transition:
-    background 0.3s ease,
-    backdrop-filter 0.3s ease,
-    border-color 0.3s ease;
-  border-bottom: 1px solid transparent;
-}
-
-.nav-dark.scrolled {
-  background: rgba(10, 10, 10, 0.9);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  border-bottom-color: rgba(255, 255, 255, 0.05);
-}
-
-/* ============================================
-   BUTTONS — MONOCHROMATIC
-   ============================================ */
-
-.btn-primary,
-.btn-primary-dark,
-.btn-outline-dark-on-white {
   font-family: var(--font-display);
+  font-size: clamp(2.25rem, 5.5vw, 4.5rem);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 0.95;
+}
+
+.text-card-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 2.4vw, 2.25rem);
   font-weight: 700;
-  text-transform: uppercase;
-  border-radius: 0;
-  transition: all 0.3s ease;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+}
+
+/* Small caps-ish label used for eyebrows and meta rows.
+   Kept from the old system because it still earns its place — it is the one
+   piece of structure that survives the soft reset. */
+.label {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+
+/* ============================================
+   GLASS SURFACES
+
+   A convincing pane needs four things at once:
+     1. a blurred, saturated backdrop
+     2. a diagonal tint — glass is never uniformly lit
+     3. a rim whose brightness *varies* around the edge (this is the tell)
+     4. depth shadow separating it from the field
+
+   The rim is drawn as a masked gradient border rather than a flat 1px line,
+   because a uniform border reads as a card and a varying one reads as a bevel.
+   ============================================ */
+
+.glass {
+  position: relative;
+  border-radius: var(--r-lg);
+  background: linear-gradient(
+    145deg,
+    var(--glass-tint-hi) 0%,
+    rgba(255, 255, 255, 0.04) 38%,
+    var(--glass-tint-lo) 100%
+  );
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  box-shadow:
+    var(--glass-shadow),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 0 rgba(255, 255, 255, 0.03);
+  isolation: isolate;
+}
+
+/* Varying rim light — bright at the top-left, fading around to nothing. */
+.glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    145deg,
+    var(--glass-rim) 0%,
+    rgba(255, 255, 255, 0.08) 30%,
+    var(--glass-rim-dim) 55%,
+    rgba(255, 255, 255, 0.1) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Specular sheen across the upper third. */
+.glass-sheen::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    120% 80% at 15% -10%,
+    rgba(255, 255, 255, 0.14) 0%,
+    rgba(255, 255, 255, 0.04) 35%,
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Card content sits above the rim and sheen pseudo-elements. Written with
+   :where() so it carries zero specificity — any utility class on a child
+   (`absolute`, a custom z-index) still wins. */
+.glass > :where(*),
+.glass-light > :where(*) {
+  position: relative;
+  z-index: 2;
+}
+
+.glass-sm {
+  --glass-blur: 16px;
+  border-radius: var(--r-sm);
+}
+
+.glass-lg {
+  border-radius: var(--r-xl);
+}
+
+/* Brighter pane — used where the old design used flat white. */
+.glass-bright {
+  --glass-tint-hi: rgba(255, 255, 255, 0.24);
+  --glass-tint-lo: rgba(255, 255, 255, 0.1);
+  --glass-rim: rgba(255, 255, 255, 0.55);
+  --glass-blur: 34px;
+}
+
+/* Interactive panes lift toward the light on hover. */
+.glass-interactive {
+  transition:
+    transform 0.55s var(--ease-glass),
+    box-shadow 0.55s var(--ease-glass),
+    background 0.55s var(--ease-glass);
+}
+
+.glass-interactive:hover {
+  transform: translateY(-4px);
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.15) 0%,
+    rgba(255, 255, 255, 0.06) 38%,
+    rgba(255, 255, 255, 0.035) 100%
+  );
+  box-shadow:
+    0 34px 80px -24px rgba(0, 0, 0, 0.9),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 0 rgba(255, 255, 255, 0.04);
+}
+
+/* ---- Light glass — the contact inversion ---- */
+
+.glass-light {
+  position: relative;
+  border-radius: var(--r-lg);
+  background: linear-gradient(
+    145deg,
+    var(--light-tint-hi) 0%,
+    rgba(255, 255, 255, 0.65) 40%,
+    var(--light-tint-lo) 100%
+  );
+  -webkit-backdrop-filter: blur(24px) saturate(150%);
+  backdrop-filter: blur(24px) saturate(150%);
+  box-shadow:
+    var(--light-shadow),
+    inset 0 1px 0 0 rgba(255, 255, 255, 1),
+    inset 0 -1px 0 0 rgba(255, 255, 255, 0.5);
+  isolation: isolate;
+}
+
+.glass-light::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    145deg,
+    var(--light-rim) 0%,
+    rgba(255, 255, 255, 0.4) 45%,
+    rgba(120, 110, 170, 0.16) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ============================================
+   AMBIENT FIELD
+   Large, soft, slow. Compositor-only transforms — no blur filter, the
+   gradients are already soft enough, which keeps this ~free to animate.
+   ============================================ */
+
+.aura-layer {
+  position: fixed;
+  inset: -20%;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.aura-orb {
+  position: absolute;
+  border-radius: 50%;
+  will-change: transform;
+  opacity: 0.55;
+}
+
+@keyframes aura-drift-a {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  33% {
+    transform: translate3d(8vw, 6vh, 0) scale(1.14);
+  }
+  66% {
+    transform: translate3d(-5vw, 10vh, 0) scale(0.92);
+  }
+}
+
+@keyframes aura-drift-b {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.05);
+  }
+  40% {
+    transform: translate3d(-10vw, -7vh, 0) scale(0.9);
+  }
+  75% {
+    transform: translate3d(6vw, 5vh, 0) scale(1.18);
+  }
+}
+
+@keyframes aura-drift-c {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(0.95);
+  }
+  50% {
+    transform: translate3d(7vw, -9vh, 0) scale(1.2);
+  }
+}
+
+/* ============================================
+   NAVBAR OVER THE LIGHT SECTION
+
+   The pill floats over both halves of the site, so it has to invert when the
+   contact section passes beneath it — otherwise it is white-on-white. Same
+   material, flipped; redefining the text tokens here means anything inside
+   that reads them (nav items, the hamburger) adapts without extra wiring.
+   ============================================ */
+
+.nav-on-light {
+  --text-primary: #16161d;
+  --text-secondary: #3a3a4d;
+  --text-muted: #5c5c72;
+  --nav-active-bg: rgba(22, 22, 40, 0.08);
+  --nav-active-rim: rgba(255, 255, 255, 0.9);
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.92) 0%,
+    rgba(255, 255, 255, 0.62) 42%,
+    rgba(255, 255, 255, 0.48) 100%
+  );
+  box-shadow:
+    0 18px 48px -24px rgba(40, 34, 80, 0.42),
+    inset 0 1px 0 0 rgba(255, 255, 255, 1);
+}
+
+.nav-on-light::before {
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(255, 255, 255, 0.5) 45%,
+    rgba(120, 110, 170, 0.22) 100%
+  );
+}
+
+/* ============================================
+   HERO HEADLINE HANDOFF
+
+   When the WebGL canvas takes over drawing the headline, the <h1> has to stay
+   in layout (the canvas measures its line boxes on every resize) *and* stay in
+   the accessibility tree — so only its paint is suppressed. `visibility:
+   hidden` would do neither: it drops the element from the a11y tree entirely,
+   which would leave screen reader users with no <h1> at all on the page.
+   ============================================ */
+
+/* Longhands, not the `-webkit-text-stroke` shorthand: Lightning CSS drops the
+   entire rule containing that shorthand, silently and with no warning, so the
+   whole declaration block vanishes from the compiled stylesheet. */
+.hero-outline {
+  color: transparent;
+  -webkit-text-stroke-width: 1.5px;
+  -webkit-text-stroke-color: rgba(255, 255, 255, 0.5);
+}
+
+.lens-handoff,
+.lens-handoff .hero-outline {
+  color: transparent;
+  -webkit-text-stroke-color: transparent;
+  user-select: none;
+}
+
+/* ============================================
+   HERO LENS
+   The disc sits above the hero content so its backdrop-filter bends the
+   ambient field *and* the copy behind it. The WebGL canvas that renders the
+   refracted headline is layered on top of this by useGlassLens.
+   ============================================ */
+
+.lens-disc {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 20;
+  border-radius: 50%;
+  pointer-events: none;
+  opacity: 0;
+  will-change: transform;
+  /* Flat interior, bright rim — a disc of glass, not a sphere. A centre-heavy
+     gradient here is what makes the lens read as a ball, so the light is
+     pushed out to the edge instead. */
+  -webkit-backdrop-filter: blur(7px) saturate(200%) brightness(1.45);
+  backdrop-filter: blur(7px) saturate(200%) brightness(1.45);
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgba(255, 255, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0.045) 58%,
+    rgba(255, 255, 255, 0.13) 84%,
+    rgba(255, 255, 255, 0.26) 100%
+  );
+  box-shadow:
+    0 22px 55px -26px rgba(0, 0, 0, 0.5),
+    0 0 50px -12px rgba(255, 255, 255, 0.1),
+    inset 0 1px 1px rgba(255, 255, 255, 0.45);
+}
+
+/* ============================================
+   BUTTONS — pills
+   ============================================ */
+
+.btn {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+  border-radius: var(--r-full);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
   cursor: pointer;
+  white-space: nowrap;
+  transition:
+    transform 0.4s var(--ease-glass),
+    box-shadow 0.4s var(--ease-glass),
+    background 0.4s var(--ease-glass),
+    color 0.4s var(--ease-glass);
 }
 
-.btn-primary {
-  background: #ffffff;
-  color: #000000;
-  font-size: 10px;
-  letter-spacing: 0.2em;
+.btn:active {
+  transform: scale(0.96);
 }
 
-.btn-primary:hover {
-  background: #333333;
+/* Solid light pill on dark — the primary action. */
+.btn-solid {
+  background: linear-gradient(180deg, #ffffff 0%, #e6e6ee 100%);
+  color: #0b0b12;
+  box-shadow:
+    0 10px 30px -10px rgba(255, 255, 255, 0.28),
+    inset 0 -1px 0 0 rgba(0, 0, 0, 0.08);
+}
+
+.btn-solid:hover {
+  box-shadow:
+    0 16px 40px -10px rgba(255, 255, 255, 0.4),
+    inset 0 -1px 0 0 rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.btn-solid:active {
+  transform: translateY(-2px) scale(0.96);
+}
+
+/* Glass pill on dark — the secondary action. */
+.btn-glass {
+  position: relative;
+  color: var(--text-primary);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0.05) 100%);
+  -webkit-backdrop-filter: blur(18px) saturate(170%);
+  backdrop-filter: blur(18px) saturate(170%);
+  box-shadow:
+    0 12px 34px -14px rgba(0, 0, 0, 0.8),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.2);
+}
+
+.btn-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.4) 0%,
+    rgba(255, 255, 255, 0.06) 60%,
+    rgba(255, 255, 255, 0.16) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.btn-glass:hover {
+  transform: translateY(-2px);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.08) 100%);
+}
+
+.btn-glass:active {
+  transform: translateY(-2px) scale(0.96);
+}
+
+/* Dark solid pill on the light section. */
+.btn-solid-dark {
+  background: linear-gradient(180deg, #26263a 0%, #101018 100%);
   color: #ffffff;
+  box-shadow:
+    0 14px 34px -12px rgba(30, 26, 70, 0.55),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
 }
 
-.btn-primary:active {
-  transform: scale(0.97);
+.btn-solid-dark:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 20px 44px -12px rgba(30, 26, 70, 0.65),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.16);
 }
 
-.btn-primary-dark {
-  background: #000000;
-  color: #ffffff;
-  font-size: 12px;
-  letter-spacing: 0.3em;
+.btn-solid-dark:active {
+  transform: translateY(-2px) scale(0.96);
 }
 
-.btn-primary-dark:hover {
-  transform: scale(1.05);
+/* Light glass pill on the light section. */
+.btn-glass-light {
+  position: relative;
+  color: var(--light-text);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.55) 100%);
+  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  backdrop-filter: blur(18px) saturate(150%);
+  box-shadow:
+    0 12px 30px -14px rgba(40, 34, 80, 0.4),
+    inset 0 1px 0 0 rgba(255, 255, 255, 1);
 }
 
-.btn-primary-dark:active {
-  transform: scale(0.95);
+.btn-glass-light::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 1) 0%, rgba(120, 110, 170, 0.18) 100%);
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
 }
 
-.btn-outline-dark-on-white {
-  border: 2px solid rgba(0, 0, 0, 0.15);
-  color: #000000;
-  background: transparent;
-  font-size: 12px;
-  letter-spacing: 0.3em;
+.btn-glass-light:hover {
+  transform: translateY(-2px);
 }
 
-.btn-outline-dark-on-white:hover {
-  background: #000000;
-  color: #ffffff;
-}
-
-/* ============================================
-   GRID OVERLAY — 80px architectural grid
-   ============================================ */
-
-.grid-overlay {
-  background-image:
-    linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px);
-  background-size: 80px 80px;
+.btn-glass-light:active {
+  transform: translateY(-2px) scale(0.96);
 }
 
 /* ============================================
@@ -171,20 +617,52 @@
 .bento-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-auto-rows: minmax(180px, auto);
-  gap: 1.5rem;
+  grid-auto-rows: minmax(150px, auto);
+  gap: 1.25rem;
 }
 
 /* ============================================
-   REVEAL BOX — IntersectionObserver driven
+   INPUTS — light glass
+   ============================================ */
+
+.input-glass-light {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(120, 110, 170, 0.18);
+  border-radius: var(--r-sm);
+  color: var(--light-text);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  box-shadow: inset 0 1px 2px rgba(40, 34, 80, 0.06);
+  transition:
+    border-color 0.35s var(--ease-glass),
+    box-shadow 0.35s var(--ease-glass),
+    background 0.35s var(--ease-glass);
+}
+
+.input-glass-light::placeholder {
+  color: rgba(92, 92, 114, 0.6);
+}
+
+.input-glass-light:focus {
+  outline: none;
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(99, 91, 255, 0.5);
+  box-shadow:
+    0 0 0 4px rgba(99, 91, 255, 0.12),
+    inset 0 1px 2px rgba(40, 34, 80, 0.05);
+}
+
+/* ============================================
+   REVEAL — IntersectionObserver driven
    ============================================ */
 
 .reveal-box {
   opacity: 0;
-  transform: translateY(30px) scale(0.98);
+  transform: translateY(26px) scale(0.985);
   transition:
-    opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+    opacity 0.9s var(--ease-glass),
+    transform 0.9s var(--ease-glass);
 }
 
 .reveal-box.active {
@@ -193,37 +671,7 @@
 }
 
 /* ============================================
-   INPUTS
-   ============================================ */
-
-.input-on-white {
-  background: #f5f5f5;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 0;
-  color: #000000;
-  transition: border-color 0.3s ease;
-}
-
-.input-on-white::placeholder {
-  color: #999999;
-}
-
-.input-on-white:focus {
-  outline: none;
-  border-color: #000000;
-}
-
-/* ============================================
-   MONOLITH BORDER
-   ============================================ */
-
-.monolith-border {
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-/* ============================================
-   NOISE OVERLAY
+   NOISE — dialled back; glass already carries the texture
    ============================================ */
 
 .noise-overlay {
@@ -231,26 +679,24 @@
   inset: 0;
   pointer-events: none;
   z-index: 999;
-  opacity: 0.025;
+  opacity: 0.018;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
 }
 
 /* ============================================
-   MOBILE RESPONSIVE
+   MOBILE
    ============================================ */
 
 @media (max-width: 768px) {
-  .text-display {
-    font-size: clamp(3rem, 14vw, 5rem);
-  }
-
-  .text-section-title {
-    font-size: clamp(2rem, 10vw, 3rem);
+  :root {
+    /* Blur is the single most expensive thing here; ease off on phones. */
+    --glass-blur: 20px;
   }
 
   .bento-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
     grid-auto-rows: auto;
+    gap: 0.875rem;
   }
 }
 
@@ -259,6 +705,10 @@
    ============================================ */
 
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
   *,
   *::before,
   *::after {
@@ -270,5 +720,9 @@
   .reveal-box {
     opacity: 1;
     transform: none;
+  }
+
+  .aura-orb {
+    animation: none !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from 'next';
-import { Manrope, Inter } from 'next/font/google';
+import { Plus_Jakarta_Sans, Inter } from 'next/font/google';
 import './globals.css';
 import { Navbar } from '@/components/sections/Navbar';
+import { AmbientField } from '@/components/ui/AmbientField';
 
-const manrope = Manrope({
+const jakarta = Plus_Jakarta_Sans({
   subsets: ['latin'],
-  weight: ['400', '700', '800'],
-  variable: '--font-manrope',
+  weight: ['400', '500', '600', '700', '800'],
+  variable: '--font-jakarta',
   display: 'swap',
 });
 
@@ -36,15 +37,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${manrope.variable} ${inter.variable}`}>
+    <html lang="en" className={`${jakarta.variable} ${inter.variable}`}>
       <body className={inter.className}>
-        {/* Architectural grid overlay */}
-        <div
-          className="fixed inset-0 pointer-events-none z-[100] grid-overlay"
-          style={{ opacity: 0.03 }}
-          aria-hidden="true"
-        />
-        <div className="noise-overlay" />
+        {/* The light source every glass surface on the page refracts. */}
+        <AmbientField />
+        <div className="noise-overlay" aria-hidden="true" />
         <Navbar />
         <main className="relative z-10">{children}</main>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,10 @@ import { ContactSection } from '@/components/sections/ContactSection';
 import { Footer } from '@/components/sections/Footer';
 
 export default function Home() {
+  // No background colour here — the ambient field lives behind everything and
+  // an opaque wrapper would hide the only thing the glass has to refract.
   return (
-    <div className="bg-[var(--background)]">
+    <div>
       <section id="home">
         <HeroHeader />
       </section>

--- a/components/sections/AboutSection.tsx
+++ b/components/sections/AboutSection.tsx
@@ -71,230 +71,169 @@ function useRevealObserver(containerRef: React.RefObject<HTMLElement | null>) {
 
     boxes.forEach((box) => observer.observe(box));
     return () => observer.disconnect();
-  }, []);
+  }, [containerRef]);
 }
+
+const STACK = [
+  { label: 'React', Icon: SiReact },
+  { label: 'Next.js', Icon: SiNextdotjs },
+  { label: 'TypeScript', Icon: SiTypescript },
+  { label: 'Node.js', Icon: SiNodedotjs },
+  { label: 'Tailwind', Icon: SiTailwindcss },
+  { label: 'GraphQL', Icon: SiGraphql },
+  { label: 'MongoDB', Icon: SiMongodb },
+  { label: 'Shopify', Icon: SiShopify },
+  { label: 'Vercel', Icon: SiVercel },
+  { label: 'Cloudflare', Icon: SiCloudflare },
+  { label: 'Java', Icon: FaJava },
+  { label: 'Solana', Icon: SiSolana },
+];
 
 export function AboutSection() {
   const containerRef = useRef<HTMLElement>(null);
   useRevealObserver(containerRef);
 
   return (
-    <section
-      ref={containerRef}
-      className="px-8 py-16 max-w-[1440px] mx-auto border-t border-white/5"
-    >
+    <section ref={containerRef} className="px-6 md:px-10 py-20 md:py-28 max-w-[1440px] mx-auto">
       <div className="bento-grid">
-        {/* 01 // CRAFT — large 2×2 philosophy card */}
-        <div
-          className="col-span-4 md:col-span-2 row-span-2 p-12 flex flex-col justify-between border border-white/5 reveal-box"
-          style={{ background: 'var(--surface-container)' }}
-        >
+        {/* Craft — the philosophy panel */}
+        <div className="col-span-2 row-span-2 glass glass-sheen glass-interactive reveal-box p-8 md:p-11 flex flex-col justify-between">
           <div>
-            <h2 className="font-display text-4xl font-bold tracking-tighter mb-8 italic text-white">
-              01 // CRAFT
-            </h2>
-            <p className="text-lg leading-relaxed font-light" style={{ color: '#c6c6c6' }}>
+            <h2 className="text-card-title mb-6 text-white">Craft</h2>
+            <p
+              className="text-[17px] leading-relaxed font-light"
+              style={{ color: 'var(--text-secondary)' }}
+            >
               I believe every interface is a built structure. Every pixel serves a purpose, and
               every interaction should feel grounded in logic. My work bridges the gap between
               precise engineering and human-centric design.
             </p>
           </div>
-          <div className="mt-12 pt-12 border-t border-white/5 space-y-4">
+          <div className="mt-10 pt-8 border-t border-white/10 space-y-4">
             <div className="flex items-center justify-between">
-              <span
-                className="font-display text-[10px] uppercase tracking-widest"
-                style={{ color: '#919191' }}
-              >
-                Experience
-              </span>
+              <span className="label">Experience</span>
               <span className="font-display font-bold tabular-nums text-white">4+ Years</span>
             </div>
             <div className="flex items-center justify-between">
-              <span
-                className="font-display text-[10px] uppercase tracking-widest"
-                style={{ color: '#919191' }}
-              >
-                Location
-              </span>
-              <span className="font-display font-bold italic text-white">Irvine, CA</span>
+              <span className="label">Location</span>
+              <span className="font-display font-bold text-white">Irvine, CA</span>
             </div>
           </div>
         </div>
 
-        {/* View Latest Works — white CTA card */}
-        <div
-          className="col-span-4 md:col-span-2 row-span-1 p-12 flex flex-col justify-between text-black group cursor-pointer overflow-hidden relative reveal-box"
-          style={{ background: '#ffffff' }}
+        {/* View latest works — the bright pane that replaces the old flat white card */}
+        <button
+          type="button"
+          className="col-span-2 glass glass-sheen glass-bright glass-interactive reveal-box p-8 md:p-9 flex flex-col justify-between gap-10 text-left group cursor-pointer overflow-hidden"
           onClick={() =>
             document.getElementById('projects')?.scrollIntoView({ behavior: 'smooth' })
           }
         >
-          <div className="flex justify-between items-start relative z-10">
-            <ArrowUpRight className="w-12 h-12 transition-transform duration-500 group-hover:translate-x-2 group-hover:-translate-y-2" />
-            <span className="font-display text-[10px] uppercase tracking-widest opacity-50">
-              Featured Gallery
-            </span>
+          <div className="flex justify-between items-start w-full">
+            <ArrowUpRight className="w-10 h-10 text-white transition-transform duration-500 group-hover:translate-x-1.5 group-hover:-translate-y-1.5" />
+            <span className="label">Featured Gallery</span>
           </div>
-          <div className="relative z-10">
-            <h3 className="font-display text-3xl font-extrabold leading-none uppercase tracking-tighter">
-              View Latest
+          <div className="w-full">
+            <h3 className="text-card-title text-white">
+              View latest
               <br />
-              Works
+              works
             </h3>
-            <p className="text-[10px] mt-4 uppercase tracking-[0.3em] font-bold opacity-50">
-              Scroll to explore
-            </p>
+            <p className="label mt-3">Scroll to explore</p>
           </div>
-          {/* Ghost watermark */}
-          <div className="absolute -right-6 -bottom-6 font-display font-extrabold text-[8rem] leading-none opacity-[0.04] select-none pointer-events-none">
-            WORK
-          </div>
-        </div>
-
-        {/* Technical Foundation — 4×3 logo grid */}
-        <div
-          className="col-span-4 md:col-span-2 row-span-1 p-10 flex flex-col justify-center border border-white/5 reveal-box"
-          style={{ background: 'var(--surface-container)' }}
-        >
-          <h3
-            className="font-display text-[10px] uppercase tracking-[0.3em] mb-6"
-            style={{ color: '#919191' }}
+          <span
+            className="absolute -right-5 -bottom-6 font-display font-extrabold text-[5.5rem] leading-none select-none pointer-events-none text-white/[0.05]"
+            aria-hidden="true"
           >
-            Technical Foundation
-          </h3>
-          <div className="grid grid-cols-4 gap-3">
-            {[
-              { label: 'React', Icon: SiReact },
-              { label: 'Next.js', Icon: SiNextdotjs },
-              { label: 'TypeScript', Icon: SiTypescript },
-              { label: 'Node.js', Icon: SiNodedotjs },
-              { label: 'Tailwind', Icon: SiTailwindcss },
-              { label: 'GraphQL', Icon: SiGraphql },
-              { label: 'MongoDB', Icon: SiMongodb },
-              { label: 'Shopify', Icon: SiShopify },
-              { label: 'Vercel', Icon: SiVercel },
-              { label: 'Cloudflare', Icon: SiCloudflare },
-              { label: 'Java', Icon: FaJava },
-              { label: 'Solana', Icon: SiSolana },
-            ].map(({ label, Icon }) => (
+            Work
+          </span>
+        </button>
+
+        {/* Technical foundation */}
+        <div className="col-span-2 glass glass-sheen reveal-box p-7 md:p-9 flex flex-col justify-center">
+          <h3 className="label mb-5">Technical Foundation</h3>
+          <div className="grid grid-cols-6 gap-2.5">
+            {STACK.map(({ label, Icon }) => (
               <div
                 key={label}
-                className="h-14 flex items-center justify-center group hover:bg-white transition-all duration-300 cursor-crosshair border border-white/5"
-                style={{ background: 'var(--surface-elevated)' }}
+                className="h-12 rounded-[14px] flex items-center justify-center transition-all duration-300 hover:scale-105"
+                style={{
+                  background: 'rgba(255,255,255,0.05)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.1)',
+                }}
                 title={label}
               >
                 <Icon
-                  size={22}
-                  className="group-hover:text-black transition-colors"
-                  style={{ color: '#c6c6c6' }}
+                  size={20}
+                  className="transition-colors duration-300 hover:text-white"
+                  style={{ color: 'var(--text-secondary)' }}
                 />
               </div>
             ))}
           </div>
         </div>
 
-        {/* Stats title card */}
-        <div className="col-span-4 md:col-span-2 row-span-2 p-12 flex flex-col justify-between overflow-hidden relative border border-white/5 reveal-box bg-black">
-          {/* Diagonal stripe pattern */}
-          <div
-            className="absolute inset-0 pointer-events-none"
+        {/* By the numbers — the darker counterpoint panel */}
+        <div className="col-span-2 row-span-2 glass glass-sheen reveal-box p-8 md:p-11 flex flex-col justify-between overflow-hidden">
+          <span className="label">By the numbers</span>
+          <div>
+            <h3 className="text-card-title text-white mb-5">
+              Impact &amp;
+              <br />
+              scale.
+            </h3>
+            <p
+              className="text-[15px] font-light leading-relaxed"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              Shipped across fintech, health, automotive, and Web3 — from enterprise platforms to
+              consumer apps used daily.
+            </p>
+          </div>
+          {/* A soft bloom in the corner so this panel catches more of the field */}
+          <span
+            className="absolute -right-16 -top-16 w-56 h-56 rounded-full pointer-events-none"
+            aria-hidden="true"
             style={{
-              backgroundImage:
-                'repeating-linear-gradient(45deg, rgba(255,255,255,0.04) 0px, rgba(255,255,255,0.04) 1px, transparent 1px, transparent 24px)',
-              opacity: 0.6,
+              background:
+                'radial-gradient(circle, rgb(var(--aura-violet) / 0.3) 0%, transparent 68%)',
             }}
           />
-          <div className="relative z-10 flex flex-col justify-between h-full">
-            <span
-              className="font-display text-[10px] uppercase tracking-[0.4em]"
-              style={{ color: 'rgba(255,255,255,0.4)' }}
-            >
-              02 // By The Numbers
-            </span>
-            <div>
-              <h3 className="font-display text-4xl font-extrabold tracking-tighter text-white italic leading-tight mb-6">
-                Impact &amp;
-                <br />
-                Scale.
-              </h3>
-              <p
-                className="text-sm font-light leading-relaxed"
-                style={{ color: 'rgba(255,255,255,0.4)' }}
-              >
-                Shipped across fintech, health, automotive, and Web3 — from enterprise platforms to
-                consumer apps used daily.
-              </p>
-            </div>
-          </div>
         </div>
 
-        {/* Components shipped */}
-        <div
-          className="col-span-2 md:col-span-1 p-8 flex flex-col items-center justify-center text-center border border-white/5 reveal-box"
-          style={{ background: 'var(--surface-container)' }}
-        >
-          <span className="text-5xl font-extrabold font-display mb-2 tabular-nums text-white">
+        {/* Stats */}
+        <div className="col-span-1 glass glass-sheen reveal-box p-6 flex flex-col items-center justify-center text-center">
+          <span className="text-4xl md:text-5xl font-extrabold font-display mb-2 tabular-nums text-white">
             <CountUp to={100} />
-            <span style={{ color: 'rgba(255,255,255,0.2)' }}>+</span>
+            <span className="text-white/25">+</span>
           </span>
-          <span
-            className="font-display text-[9px] uppercase tracking-[0.3em]"
-            style={{ color: '#919191' }}
-          >
-            Components Shipped
-          </span>
+          <span className="label text-center leading-snug">Components Shipped</span>
         </div>
 
-        {/* Fortune 500 clients */}
-        <div
-          className="col-span-2 md:col-span-1 p-8 flex flex-col items-center justify-center text-center border border-white/5 reveal-box"
-          style={{ background: 'var(--surface-container)' }}
-        >
-          <span className="text-5xl font-extrabold font-display mb-2 tabular-nums text-white">
+        <div className="col-span-1 glass glass-sheen reveal-box p-6 flex flex-col items-center justify-center text-center">
+          <span className="text-4xl md:text-5xl font-extrabold font-display mb-2 tabular-nums text-white">
             F
-            <span style={{ color: 'rgba(255,255,255,0.2)' }}>
+            <span className="text-white/25">
               <CountUp to={500} />
             </span>
           </span>
-          <span
-            className="font-display text-[9px] uppercase tracking-[0.3em]"
-            style={{ color: '#919191' }}
-          >
-            Enterprise Clients
-          </span>
+          <span className="label text-center leading-snug">Enterprise Clients</span>
         </div>
 
-        {/* Technologies */}
-        <div
-          className="col-span-2 md:col-span-1 p-8 flex flex-col items-center justify-center text-center border border-white/5 reveal-box"
-          style={{ background: 'var(--surface-container)' }}
-        >
-          <span className="text-5xl font-extrabold font-display mb-2 tabular-nums text-white">
+        <div className="col-span-1 glass glass-sheen reveal-box p-6 flex flex-col items-center justify-center text-center">
+          <span className="text-4xl md:text-5xl font-extrabold font-display mb-2 tabular-nums text-white">
             <CountUp to={20} />
-            <span style={{ color: 'rgba(255,255,255,0.2)' }}>+</span>
+            <span className="text-white/25">+</span>
           </span>
-          <span
-            className="font-display text-[9px] uppercase tracking-[0.3em]"
-            style={{ color: '#919191' }}
-          >
-            Technologies
-          </span>
+          <span className="label text-center leading-snug">Technologies</span>
         </div>
 
-        {/* Availability */}
-        <div
-          className="col-span-2 md:col-span-1 p-8 flex flex-col items-center justify-center text-center border border-white/5 reveal-box"
-          style={{ background: 'var(--surface-container)' }}
-        >
-          <span className="text-4xl mb-3" style={{ color: 'rgba(255,255,255,0.25)' }}>
-            ✦
+        <div className="col-span-1 glass glass-sheen reveal-box p-6 flex flex-col items-center justify-center text-center">
+          <span className="relative flex h-2.5 w-2.5 mb-4">
+            <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-60 animate-ping" />
+            <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-300" />
           </span>
-          <span
-            className="font-display text-[9px] uppercase tracking-[0.3em]"
-            style={{ color: '#919191' }}
-          >
-            Available for Work
-          </span>
+          <span className="label text-center leading-snug">Available for Work</span>
         </div>
       </div>
     </section>

--- a/components/sections/ContactSection.tsx
+++ b/components/sections/ContactSection.tsx
@@ -4,6 +4,42 @@ import { motion } from 'framer-motion';
 import { useState } from 'react';
 import { Check } from 'lucide-react';
 
+/**
+ * The inversion beat.
+ *
+ * Same material, flipped: a pale luminous field with frosted white panels
+ * over it, rather than a different design language. The section is opaque so
+ * it fully covers the site's dark ambient layer, then lays down its own
+ * light-tinted orbs for the glass here to refract.
+ */
+function LightField() {
+  return (
+    <div className="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
+      <div
+        className="absolute -top-[20%] -left-[10%] w-[60vw] h-[60vw] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgb(var(--aura-indigo) / 0.22) 0%, transparent 66%)',
+          animation: 'aura-drift-a 38s ease-in-out infinite',
+        }}
+      />
+      <div
+        className="absolute top-[30%] right-[-8%] w-[46vw] h-[46vw] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgb(var(--aura-violet) / 0.2) 0%, transparent 66%)',
+          animation: 'aura-drift-b 45s ease-in-out infinite',
+        }}
+      />
+      <div
+        className="absolute bottom-[-15%] left-[25%] w-[42vw] h-[42vw] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgb(var(--aura-teal) / 0.14) 0%, transparent 68%)',
+          animation: 'aura-drift-c 52s ease-in-out infinite',
+        }}
+      />
+    </div>
+  );
+}
+
 export function ContactSection() {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -38,57 +74,57 @@ export function ContactSection() {
   }
 
   return (
-    <section className="bg-white px-8 py-32 text-center text-black relative overflow-hidden">
-      <div
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          opacity: 0.04,
-          backgroundImage: 'radial-gradient(#000 1.5px, transparent 1.5px)',
-          backgroundSize: '30px 30px',
-        }}
-        aria-hidden="true"
-      />
+    <section
+      className="relative overflow-hidden px-6 md:px-10 py-28 md:py-36 text-center"
+      style={{ background: 'var(--light-bg)', color: 'var(--light-text)' }}
+    >
+      <LightField />
 
       <div className="relative z-10 max-w-4xl mx-auto">
-        <motion.span
-          className="font-display text-[10px] uppercase tracking-[0.5em] mb-8 block"
-          style={{ opacity: 0.4 }}
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 0.4 }}
+        <motion.div
+          className="inline-flex items-center gap-2.5 px-4 py-2 mb-10 rounded-full btn-glass-light"
+          initial={{ opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6 }}
+          transition={{ duration: 0.7, ease: [0.32, 0.72, 0, 1] }}
         >
-          Available for new projects
-        </motion.span>
+          <span className="relative flex h-1.5 w-1.5">
+            <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-500 opacity-60 animate-ping" />
+            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+          </span>
+          <span className="font-display text-[12px] font-semibold tracking-tight">
+            Available for new projects
+          </span>
+        </motion.div>
 
         <motion.h2
-          className="font-display font-extrabold tracking-tighter uppercase leading-[0.85] mb-20"
-          style={{ fontSize: 'clamp(3rem, 8vw, 7.5rem)' }}
+          className="font-display font-extrabold tracking-tight leading-[0.92] mb-14"
+          style={{ fontSize: 'clamp(2.75rem, 8vw, 7rem)' }}
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6, delay: 0.1 }}
+          transition={{ duration: 0.7, ease: [0.32, 0.72, 0, 1], delay: 0.1 }}
         >
-          Let's Build
+          Let&apos;s build
           <br />
-          Something
+          something
           <br />
-          Together.
+          together.
         </motion.h2>
 
         <motion.div
-          className="flex flex-col md:flex-row gap-6 justify-center items-center"
+          className="flex flex-col sm:flex-row gap-4 justify-center items-stretch sm:items-center"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6, delay: 0.2 }}
+          transition={{ duration: 0.7, ease: [0.32, 0.72, 0, 1], delay: 0.2 }}
         >
           <button
             onClick={() => {
               setIsFormOpen(!isFormOpen);
               setIsSubmitted(false);
             }}
-            className="btn-primary-dark px-14 py-6"
+            className="btn btn-solid-dark px-10 py-4"
           >
             {isFormOpen ? 'Close' : 'Start a Project'}
           </button>
@@ -96,7 +132,7 @@ export function ContactSection() {
             href="/resume.pdf"
             target="_blank"
             rel="noopener noreferrer"
-            className="btn-outline-dark-on-white px-14 py-6"
+            className="btn btn-glass-light px-10 py-4"
           >
             View Resume
           </a>
@@ -104,95 +140,112 @@ export function ContactSection() {
 
         {isFormOpen && (
           <motion.div
-            className="mt-20 max-w-xl mx-auto text-left"
+            className="mt-14 max-w-xl mx-auto text-left"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4 }}
+            transition={{ duration: 0.5, ease: [0.32, 0.72, 0, 1] }}
           >
-            {isSubmitted ? (
-              <div className="flex flex-col items-center gap-4 text-center">
-                <div className="w-12 h-12 border-2 border-black flex items-center justify-center">
-                  <Check className="w-5 h-5" />
-                </div>
-                <h3 className="font-display font-extrabold text-2xl tracking-tighter">
-                  Message Sent
-                </h3>
-                <p className="text-sm" style={{ opacity: 0.6 }}>
-                  I&apos;ll get back to you soon.
-                </p>
-                <button
-                  onClick={() => {
-                    setIsSubmitted(false);
-                    setIsFormOpen(false);
-                  }}
-                  className="btn-outline-dark-on-white px-8 py-3 text-[10px] mt-2"
-                >
-                  Close
-                </button>
-              </div>
-            ) : (
-              <form onSubmit={handleSubmit} className="space-y-5">
-                <div>
-                  <label className="block font-display text-[10px] font-bold uppercase tracking-widest mb-2 opacity-50">
-                    Name *
-                  </label>
-                  <input
-                    type="text"
-                    name="name"
-                    required
-                    className="input-on-white w-full px-4 py-3 text-sm"
-                    placeholder="Your name"
-                  />
-                </div>
-
-                <div>
-                  <label className="block font-display text-[10px] font-bold uppercase tracking-widest mb-2 opacity-50">
-                    Email *
-                  </label>
-                  <input
-                    type="email"
-                    name="email"
-                    required
-                    className="input-on-white w-full px-4 py-3 text-sm"
-                    placeholder="your@email.com"
-                  />
-                </div>
-
-                <div>
-                  <label className="block font-display text-[10px] font-bold uppercase tracking-widest mb-2 opacity-50">
-                    Message *
-                  </label>
-                  <textarea
-                    name="message"
-                    required
-                    rows={4}
-                    className="input-on-white w-full px-4 py-3 text-sm resize-none"
-                    placeholder="Tell me about your project..."
-                  />
-                </div>
-
-                {isError && (
-                  <p className="text-sm text-red-600">
-                    There was an error sending your message. Please try again.
+            <div className="glass-light p-7 md:p-9">
+              {isSubmitted ? (
+                <div className="flex flex-col items-center gap-4 text-center py-4">
+                  <div
+                    className="w-14 h-14 rounded-full flex items-center justify-center"
+                    style={{
+                      background: 'rgba(16,185,129,0.14)',
+                      boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.8)',
+                    }}
+                  >
+                    <Check className="w-6 h-6 text-emerald-600" />
+                  </div>
+                  <h3 className="font-display font-extrabold text-2xl tracking-tight">
+                    Message Sent
+                  </h3>
+                  <p className="text-sm" style={{ color: 'var(--light-text-muted)' }}>
+                    I&apos;ll get back to you soon.
                   </p>
-                )}
+                  <button
+                    onClick={() => {
+                      setIsSubmitted(false);
+                      setIsFormOpen(false);
+                    }}
+                    className="btn btn-glass-light px-8 py-3 mt-2"
+                  >
+                    Close
+                  </button>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit} className="space-y-5">
+                  <div>
+                    <label
+                      className="block font-display text-[12px] font-semibold tracking-tight mb-2"
+                      style={{ color: 'var(--light-text-muted)' }}
+                    >
+                      Name *
+                    </label>
+                    <input
+                      type="text"
+                      name="name"
+                      required
+                      className="input-glass-light px-4 py-3.5 text-sm"
+                      placeholder="Your name"
+                    />
+                  </div>
 
-                <button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="btn-primary-dark w-full py-4 flex items-center justify-center gap-2 disabled:opacity-50"
-                >
-                  {isSubmitting ? (
-                    <>
-                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                      Sending...
-                    </>
-                  ) : (
-                    'Send Message'
+                  <div>
+                    <label
+                      className="block font-display text-[12px] font-semibold tracking-tight mb-2"
+                      style={{ color: 'var(--light-text-muted)' }}
+                    >
+                      Email *
+                    </label>
+                    <input
+                      type="email"
+                      name="email"
+                      required
+                      className="input-glass-light px-4 py-3.5 text-sm"
+                      placeholder="your@email.com"
+                    />
+                  </div>
+
+                  <div>
+                    <label
+                      className="block font-display text-[12px] font-semibold tracking-tight mb-2"
+                      style={{ color: 'var(--light-text-muted)' }}
+                    >
+                      Message *
+                    </label>
+                    <textarea
+                      name="message"
+                      required
+                      rows={4}
+                      className="input-glass-light px-4 py-3.5 text-sm resize-none"
+                      placeholder="Tell me about your project..."
+                    />
+                  </div>
+
+                  {isError && (
+                    <p className="text-sm text-red-600">
+                      There was an error sending your message. Please try again.
+                    </p>
                   )}
-                </button>
-              </form>
-            )}
+
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="btn btn-solid-dark w-full py-4 disabled:opacity-50"
+                  >
+                    {isSubmitting ? (
+                      <>
+                        <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                        Sending...
+                      </>
+                    ) : (
+                      'Send Message'
+                    )}
+                  </button>
+                </form>
+              )}
+            </div>
           </motion.div>
         )}
       </div>

--- a/components/sections/Footer.tsx
+++ b/components/sections/Footer.tsx
@@ -1,43 +1,34 @@
+const links = [
+  { label: 'Github', href: 'https://github.com/jack-at-alice' },
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/in/jackknoell/' },
+  { label: 'Resume', href: '/resume.pdf' },
+];
+
 export function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="w-full border-t border-white/5" style={{ background: '#0a0a0a' }}>
-      <div className="flex flex-col md:flex-row justify-between items-center px-8 py-16 max-w-[1440px] mx-auto gap-6">
+    <footer className="relative w-full px-6 md:px-10 py-10">
+      <div className="glass max-w-[1440px] mx-auto !rounded-full px-7 py-5 flex flex-col md:flex-row justify-between items-center gap-5">
         <div
-          className="font-display text-[9px] uppercase tracking-[0.3em] border-l border-[#222] pl-4"
-          style={{ color: '#444444' }}
+          className="font-display text-[12px] font-medium"
+          style={{ color: 'var(--text-muted)' }}
         >
-          © {year} JACK KNOELL. ALL RIGHTS RESERVED.
+          © {year} Jack Knoell. All rights reserved.
         </div>
-        <div className="flex gap-10">
-          <a
-            href="https://github.com/jack-at-alice"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-display text-[9px] uppercase tracking-[0.3em] hover:text-white transition-colors"
-            style={{ color: '#666666' }}
-          >
-            Github
-          </a>
-          <a
-            href="https://www.linkedin.com/in/jackknoell/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-display text-[9px] uppercase tracking-[0.3em] hover:text-white transition-colors"
-            style={{ color: '#666666' }}
-          >
-            LinkedIn
-          </a>
-          <a
-            href="/resume.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-display text-[9px] uppercase tracking-[0.3em] hover:text-white transition-colors"
-            style={{ color: '#666666' }}
-          >
-            Resume
-          </a>
+        <div className="flex gap-2">
+          {links.map(({ label, href }) => (
+            <a
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-display text-[13px] font-medium px-4 py-2 rounded-full transition-all duration-300 hover:bg-white/[0.07] hover:text-white"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              {label}
+            </a>
+          ))}
         </div>
       </div>
     </footer>

--- a/components/sections/HeroHeader.tsx
+++ b/components/sections/HeroHeader.tsx
@@ -1,100 +1,115 @@
 'use client';
 
+import { useRef } from 'react';
 import { motion } from 'framer-motion';
+import { ArrowDown } from 'lucide-react';
+import { useGlassLens } from '@/lib/hooks/useGlassLens';
 
 export function HeroHeader() {
-  return (
-    <section className="relative min-h-[90vh] flex flex-col justify-center px-8 max-w-[1440px] mx-auto pt-24 pb-12">
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-end">
-        {/* Left: Headline */}
-        <div className="md:col-span-8 relative z-10">
-          {/* Eyebrow */}
-          <div className="overflow-hidden mb-4">
-            <motion.span
-              className="font-display text-[10px] uppercase tracking-[0.4em] block"
-              style={{ color: '#919191' }}
-              initial={{ y: '100%' }}
-              animate={{ y: 0 }}
-              transition={{ duration: 1, ease: [0.33, 1, 0.68, 1], delay: 0.4 }}
-            >
-              Full-Stack Developer
-            </motion.span>
-          </div>
+  const hostRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const discRef = useRef<HTMLDivElement>(null);
 
-          {/* Main headline */}
-          <h1 className="text-display font-display mb-10 text-white">
-            <span className="block overflow-hidden">
-              <motion.span
-                className="block"
-                initial={{ y: '100%' }}
-                animate={{ y: 0 }}
-                transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1], delay: 0.5 }}
-              >
-                JACK
-              </motion.span>
+  // Takes over the headline once WebGL is confirmed working, hiding the <h1>
+  // directly. Until then — and under reduced motion, or with no WebGL — the
+  // heading below renders as ordinary text.
+  useGlassLens(hostRef, titleRef, discRef);
+
+  return (
+    <div
+      ref={hostRef}
+      className="relative min-h-[92vh] flex flex-col justify-center px-6 md:px-10 max-w-[1440px] mx-auto pt-32 pb-20"
+    >
+      <div className="relative z-10 grid grid-cols-1 md:grid-cols-12 gap-10 md:gap-8 items-end">
+        {/* Left — the headline the lens refracts */}
+        <div className="md:col-span-8">
+          <motion.div
+            className="inline-flex items-center gap-2.5 px-4 py-2 mb-8 rounded-full btn-glass"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: [0.32, 0.72, 0, 1], delay: 0.25 }}
+          >
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-70 animate-ping" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-300" />
             </span>
-            <span className="block overflow-hidden">
-              <motion.span
-                className="block"
-                initial={{ y: '100%' }}
-                animate={{ y: 0 }}
-                transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1], delay: 0.65 }}
-              >
-                KNOELL
-              </motion.span>
-            </span>
-            {/* Stroke-only line — fills white on hover */}
-            <motion.span
-              className="block text-transparent hover:text-white transition-colors duration-700 cursor-default select-none"
-              style={{ WebkitTextStroke: '1px rgba(255,255,255,0.25)' }}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 1, delay: 0.9 }}
+            <span
+              className="font-display text-[12px] font-semibold tracking-tight"
+              style={{ color: 'var(--text-secondary)' }}
             >
-              DEV.
-            </motion.span>
+              Full-stack developer
+            </span>
+          </motion.div>
+
+          {/* Kept in the document for search engines, screen readers and any
+              browser without WebGL — hidden only once the canvas is live. */}
+          <h1 ref={titleRef} className="text-display mb-12 text-white">
+            <span className="block">
+              <span data-lens-line className="inline-block">
+                Jack
+              </span>
+            </span>
+            <span className="block">
+              <span data-lens-line className="inline-block">
+                Knoell
+              </span>
+            </span>
+            <span className="block">
+              <span data-lens-line data-lens-outline className="hero-outline inline-block">
+                Dev.
+              </span>
+            </span>
           </h1>
         </div>
 
-        {/* Right: Description + CTA */}
+        {/* Right — context and the way in */}
         <motion.div
-          className="md:col-span-4 pb-4 md:pb-12"
-          initial={{ opacity: 0, y: 20 }}
+          className="md:col-span-4 md:pb-6"
+          initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 1.05 }}
+          transition={{ duration: 0.9, ease: [0.32, 0.72, 0, 1], delay: 0.85 }}
         >
-          <p
-            className="max-w-xs text-sm leading-relaxed border-l-2 border-white/50 pl-6"
-            style={{ color: '#c6c6c6' }}
-          >
-            Crafting high-performance web experiences through the lens of architectural precision
-            and technical craft.
-          </p>
-          <div className="mt-8 pl-6">
-            <a
-              href="#projects"
-              onClick={(e) => {
-                e.preventDefault();
-                document.getElementById('projects')?.scrollIntoView({ behavior: 'smooth' });
-              }}
-              className="btn-primary px-8 py-3"
+          <div className="glass glass-sheen p-6 md:p-7">
+            <p
+              className="relative z-10 text-[15px] leading-relaxed"
+              style={{ color: 'var(--text-secondary)' }}
             >
-              View Work
-            </a>
+              Crafting high-performance web experiences through the lens of architectural precision
+              and technical craft.
+            </p>
+            <div className="relative z-10 mt-7">
+              <a
+                href="#projects"
+                onClick={(e) => {
+                  e.preventDefault();
+                  document.getElementById('projects')?.scrollIntoView({ behavior: 'smooth' });
+                }}
+                className="btn btn-solid px-7 py-3.5 w-full"
+              >
+                View work
+              </a>
+            </div>
           </div>
         </motion.div>
       </div>
 
-      {/* Hero background — subtle grid pattern */}
-      <div
-        className="absolute right-0 top-1/2 -translate-y-1/2 w-1/2 h-4/5 -z-10"
-        aria-hidden="true"
-        style={{
-          opacity: 0.15,
-          background:
-            'repeating-linear-gradient(0deg, rgba(255,255,255,0.06) 0px, rgba(255,255,255,0.06) 1px, transparent 1px, transparent 80px), repeating-linear-gradient(90deg, rgba(255,255,255,0.06) 0px, rgba(255,255,255,0.06) 1px, transparent 1px, transparent 80px)',
-        }}
-      />
-    </section>
+      {/* Scroll cue */}
+      <motion.div
+        className="relative z-10 mt-16 flex items-center gap-3"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1, delay: 1.6 }}
+      >
+        <ArrowDown className="w-3.5 h-3.5" style={{ color: 'var(--text-faint)' }} />
+        <span className="label" style={{ color: 'var(--text-faint)' }}>
+          Scroll
+        </span>
+      </motion.div>
+
+      {/* The glass disc itself — sits above the content so its backdrop-filter
+          bends the ambient field and the copy behind it. The canvas the hook
+          appends renders the refracted headline on top of this. */}
+      <div ref={discRef} className="lens-disc" aria-hidden="true" />
+    </div>
   );
 }

--- a/components/sections/Navbar.tsx
+++ b/components/sections/Navbar.tsx
@@ -18,20 +18,38 @@ const navItems: NavItem[] = [
 const desktopNavItems = navItems.filter((item) => item.id !== 'home');
 
 export function Navbar() {
-  const [scrolled, setScrolled] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const [onLight, setOnLight] = useState(false);
   const { activeSection, handleNavClick } = useNavigation(navItems);
 
   useEffect(() => {
-    const timer = setTimeout(() => setIsVisible(true), 300);
+    const timer = setTimeout(() => setIsVisible(true), 250);
     return () => clearTimeout(timer);
   }, []);
 
+  // The pill floats over both the dark sections and the light contact
+  // inversion, so it has to flip material when contact passes underneath it.
   useEffect(() => {
-    const handleScroll = () => setScrolled(window.scrollY > 100);
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
+    let raf = 0;
+    const check = () => {
+      raf = 0;
+      const el = document.getElementById('contact');
+      if (!el) return;
+      const { top, bottom } = el.getBoundingClientRect();
+      setOnLight(top <= 92 && bottom >= 16);
+    };
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(check);
+    };
+    check();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true });
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
   }, []);
 
   const handleMobileNavClick = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
@@ -43,54 +61,71 @@ export function Navbar() {
     <AnimatePresence>
       {isVisible && (
         <motion.header
-          className={`fixed top-0 left-0 right-0 z-50 nav-dark ${scrolled ? 'scrolled' : ''}`}
-          initial={{ opacity: 0, y: -16 }}
+          className="fixed top-4 left-0 right-0 z-50 px-4 md:px-6"
+          initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, ease: [0.33, 1, 0.68, 1] }}
+          transition={{ duration: 0.8, ease: [0.32, 0.72, 0, 1] }}
         >
-          <div className="max-w-[1440px] mx-auto px-8 py-6 flex items-center justify-between">
-            {/* Wordmark */}
+          {/* A detached pill rather than a full-width bar — it lets the
+              ambient field read continuously behind and above it. */}
+          <div
+            className={`glass glass-sheen max-w-[1200px] mx-auto !rounded-full pl-6 pr-2 py-2 flex items-center justify-between transition-[background,box-shadow] duration-500 ${
+              onLight ? 'nav-on-light' : ''
+            }`}
+          >
             <Link
               href="/#home"
               onClick={(e) => handleNavClick(e, '/#home')}
-              className="font-display font-extrabold text-xl tracking-tighter text-white hover:opacity-60 transition-opacity"
+              className="relative z-10 font-display font-extrabold text-lg tracking-tight hover:opacity-70 transition-opacity"
+              style={{ color: 'var(--text-primary)' }}
             >
               JK.
             </Link>
 
-            {/* Desktop Nav */}
-            <nav className="hidden md:flex items-center gap-10">
+            {/* Desktop nav */}
+            <nav className="hidden md:flex items-center gap-1 relative z-10">
               {desktopNavItems.map((item) => (
                 <Link
                   key={item.id}
                   href={item.href}
                   onClick={(e) => handleNavClick(e, item.href)}
-                  className="font-display font-bold text-[11px] uppercase tracking-[0.25em] transition-colors pb-0.5"
+                  className="relative px-4 py-2 rounded-full font-display text-[13px] font-medium transition-colors duration-300"
                   style={{
-                    color: activeSection === item.id ? '#ffffff' : '#888888',
-                    borderBottom:
-                      activeSection === item.id ? '1px solid #ffffff' : '1px solid transparent',
+                    color: activeSection === item.id ? 'var(--text-primary)' : 'var(--text-muted)',
                   }}
                 >
-                  {item.label}
+                  {activeSection === item.id && (
+                    <motion.span
+                      layoutId="nav-active"
+                      className="absolute inset-0 rounded-full"
+                      style={{
+                        background: 'var(--nav-active-bg)',
+                        boxShadow: 'inset 0 1px 0 var(--nav-active-rim)',
+                      }}
+                      transition={{ type: 'spring', stiffness: 380, damping: 32 }}
+                    />
+                  )}
+                  <span className="relative">{item.label}</span>
                 </Link>
               ))}
               <a
                 href="/resume.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="btn-primary px-7 py-2.5"
+                className={`btn ml-3 px-6 py-2.5 text-[13px] ${
+                  onLight ? 'btn-solid-dark' : 'btn-solid'
+                }`}
               >
                 Resume
               </a>
             </nav>
 
             {/* Mobile hamburger */}
-            <div className="md:hidden">
+            <div className="md:hidden relative z-10">
               <Button
                 variant="ghost"
                 size="icon"
-                className="!h-10 !w-10 !p-0 border-0 hover:bg-white/10 rounded-none"
+                className="!h-10 !w-10 !p-0 border-0 hover:bg-white/10 rounded-full"
                 onClick={() => setIsOpen(!isOpen)}
               >
                 <HamburgerButton isOpen={isOpen} />
@@ -99,20 +134,24 @@ export function Navbar() {
             </div>
           </div>
 
-          {/* Mobile Sheet */}
+          {/* Mobile sheet */}
           <Sheet open={isOpen} onOpenChange={setIsOpen}>
             <SheetContent
               side="right"
-              className="w-screen max-w-[100vw] h-screen p-0 border-0 overflow-hidden rounded-none"
-              style={{ background: '#0a0a0a' }}
+              className="w-screen max-w-[100vw] h-screen p-0 border-0 overflow-hidden"
+              style={{
+                background: 'rgba(6,6,8,0.72)',
+                WebkitBackdropFilter: 'blur(40px) saturate(180%)',
+                backdropFilter: 'blur(40px) saturate(180%)',
+              }}
             >
               <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
 
-              <div className="fixed right-6 top-5 z-50">
+              <div className="fixed right-7 top-7 z-50">
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="!h-10 !w-10 !p-0 border-0 hover:bg-white/10 rounded-none"
+                  className="!h-10 !w-10 !p-0 border-0 hover:bg-white/10 rounded-full"
                   onClick={() => setIsOpen(false)}
                 >
                   <HamburgerButton isOpen={true} />
@@ -120,35 +159,37 @@ export function Navbar() {
                 </Button>
               </div>
 
-              <nav className="flex flex-col p-8 pt-24 gap-1">
+              <nav className="flex flex-col p-8 pt-28 gap-2">
                 {navItems.map((item, index) => (
                   <motion.div
                     key={item.href}
-                    initial={{ opacity: 0, x: 40 }}
+                    initial={{ opacity: 0, x: 32 }}
                     animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: index * 0.06, duration: 0.4 }}
+                    transition={{ delay: index * 0.06, duration: 0.5, ease: [0.32, 0.72, 0, 1] }}
                   >
                     <Link
                       href={item.href}
                       onClick={(e) => handleMobileNavClick(e, item.href)}
-                      className="block font-display font-extrabold text-5xl tracking-tighter py-3 transition-colors"
-                      style={{ color: activeSection === item.id ? '#ffffff' : '#444444' }}
+                      className="block font-display font-extrabold text-5xl tracking-tight py-3 transition-colors"
+                      style={{
+                        color: activeSection === item.id ? '#ffffff' : 'var(--text-faint)',
+                      }}
                     >
                       {item.label}
                     </Link>
                   </motion.div>
                 ))}
                 <motion.div
-                  className="mt-8"
+                  className="mt-10"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
-                  transition={{ delay: 0.4 }}
+                  transition={{ delay: 0.35 }}
                 >
                   <a
                     href="/resume.pdf"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="btn-primary px-10 py-4"
+                    className="btn btn-solid px-10 py-4"
                   >
                     Resume
                   </a>

--- a/components/sections/ProjectsSection.tsx
+++ b/components/sections/ProjectsSection.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from 'react';
 import { motion, useScroll, useTransform } from 'framer-motion';
+import { ArrowUpRight } from 'lucide-react';
 import { ProjectCard } from '@/components/ui/ProjectCard';
 import type { Project } from '@/lib/types';
 
@@ -89,45 +90,40 @@ const projects: Project[] = [
   },
 ];
 
+function SectionHeading() {
+  return (
+    <>
+      <h2 className="text-section-title text-white">Selected works</h2>
+      <p className="label mt-3">Systems &amp; Interfaces</p>
+    </>
+  );
+}
+
 function MobileProjects() {
   return (
-    <section className="bg-black monolith-border py-16">
+    <section className="py-20">
       <div className="px-6 max-w-[1440px] mx-auto">
-        <h2 className="text-section-title font-display uppercase tracking-tighter text-white mb-2">
-          Selected Works
-        </h2>
-        <p
-          className="font-display text-[10px] uppercase tracking-[0.5em] mb-12"
-          style={{ color: '#919191' }}
-        >
-          Systems &amp; Interfaces
-        </p>
-        <div className="space-y-12 border-t border-white/10 pt-8">
-          {projects.map((project, index) => (
+        <SectionHeading />
+        <div className="mt-10 space-y-3">
+          {projects.map((project) => (
             <a
               key={project.id}
               href={project.appStoreLinks?.apple || project.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="block group"
+              className="glass glass-sheen glass-interactive block p-5 group"
             >
-              <div className="flex justify-between items-start border-l border-white/20 pl-4">
-                <div>
-                  <h3 className="font-display font-extrabold tracking-tighter text-white text-xl mb-1">
-                    {project.title.toUpperCase()}
+              <div className="flex justify-between items-center gap-4">
+                <div className="min-w-0">
+                  <h3 className="font-display font-bold tracking-tight text-white text-lg truncate">
+                    {project.title}
                   </h3>
-                  <p
-                    className="font-display text-[10px] uppercase tracking-widest"
-                    style={{ color: '#919191' }}
-                  >
-                    {project.technologies.slice(0, 2).join(' / ')}
+                  <p className="label mt-1 truncate">
+                    {project.technologies.slice(0, 2).join(' · ')}
                   </p>
                 </div>
-                <span
-                  className="font-display font-extrabold tabular-nums text-2xl"
-                  style={{ color: 'rgba(255,255,255,0.1)' }}
-                >
-                  {String(index + 1).padStart(2, '0')}
+                <span className="shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-white/[0.07]">
+                  <ArrowUpRight className="w-4 h-4 text-white" />
                 </span>
               </div>
             </a>
@@ -181,35 +177,38 @@ export function ProjectsSection() {
 
   return (
     <section ref={sectionRef}>
-      <div className="sticky top-0 h-screen overflow-hidden bg-black monolith-border">
-        {/* Ghost watermark text */}
-        <motion.h2
-          className="absolute font-display font-extrabold uppercase leading-none pointer-events-none select-none text-white"
+      <div className="sticky top-0 h-screen overflow-hidden">
+        {/* A soft veil rather than flat black — it deepens the field so the
+            cards read as lit, without cutting the ambient off entirely. */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          aria-hidden="true"
+          style={{
+            background:
+              'linear-gradient(180deg, rgba(3,3,5,0.55) 0%, rgba(3,3,5,0.2) 45%, rgba(3,3,5,0.6) 100%)',
+          }}
+        />
+
+        {/* Ghost word — the glass cards refract it as they pass */}
+        <motion.span
+          className="absolute font-display font-extrabold leading-none pointer-events-none select-none text-white/[0.035]"
+          aria-hidden="true"
           style={{
             fontSize: '15vw',
-            opacity: 0.03,
             top: '50%',
             left: 0,
-            transform: 'translateY(-50%)',
+            translateY: '-50%',
             x: bgTextX,
             whiteSpace: 'nowrap',
           }}
         >
-          ARCHITECTURE
-        </motion.h2>
+          Architecture
+        </motion.span>
 
-        {/* Section title — top left */}
-        <div className="absolute top-0 left-0 right-0 px-8 pt-24 z-10 pointer-events-none">
+        {/* Section title */}
+        <div className="absolute top-0 left-0 right-0 px-6 md:px-10 pt-28 z-10 pointer-events-none">
           <div className="max-w-[1440px] mx-auto">
-            <h2 className="text-section-title font-display uppercase tracking-tighter text-white">
-              03 // Selected Works
-            </h2>
-            <p
-              className="font-display text-[10px] uppercase tracking-[0.5em] mt-2"
-              style={{ color: '#919191' }}
-            >
-              Systems &amp; Interfaces
-            </p>
+            <SectionHeading />
           </div>
         </div>
 
@@ -217,10 +216,10 @@ export function ProjectsSection() {
         <div className="absolute inset-0 flex items-center">
           <motion.div
             ref={contentRef}
-            className="flex items-center gap-10"
+            className="flex items-center gap-8"
             style={{
               x,
-              paddingLeft: 'max(2rem, calc((100vw - 1440px) / 2 + 2rem))',
+              paddingLeft: 'max(2.5rem, calc((100vw - 1440px) / 2 + 2.5rem))',
               paddingRight: '8rem',
             }}
           >

--- a/components/ui/AmbientField.tsx
+++ b/components/ui/AmbientField.tsx
@@ -1,0 +1,92 @@
+/**
+ * The light source for the whole site.
+ *
+ * Glass is a refractive material — `backdrop-filter` over a flat background
+ * produces nothing at all. These orbs are what every glass surface on the page
+ * is actually bending and tinting, so this layer is structural rather than
+ * decorative.
+ *
+ * Kept cheap on purpose: radial gradients are soft enough that no `filter:
+ * blur()` is needed, and the drift animates `transform` only, so the whole
+ * thing stays on the compositor.
+ */
+
+type Orb = {
+  hue: string;
+  size: string;
+  top: string;
+  left: string;
+  opacity: number;
+  animation: string;
+};
+
+const ORBS: Orb[] = [
+  {
+    hue: 'var(--aura-indigo)',
+    size: '62vw',
+    top: '-12%',
+    left: '-10%',
+    opacity: 0.95,
+    animation: 'aura-drift-a 34s ease-in-out infinite',
+  },
+  {
+    hue: 'var(--aura-violet)',
+    size: '50vw',
+    top: '18%',
+    left: '44%',
+    opacity: 0.8,
+    animation: 'aura-drift-b 41s ease-in-out infinite',
+  },
+  {
+    hue: 'var(--aura-indigo)',
+    size: '56vw',
+    top: '56%',
+    left: '0%',
+    opacity: 0.7,
+    animation: 'aura-drift-c 47s ease-in-out infinite',
+  },
+  // Teal stays a thin accent — enough to keep the field from going monotone
+  // violet, not enough to read as a second brand colour.
+  {
+    hue: 'var(--aura-teal)',
+    size: '38vw',
+    top: '68%',
+    left: '56%',
+    opacity: 0.34,
+    animation: 'aura-drift-b 53s ease-in-out infinite reverse',
+  },
+];
+
+export function AmbientField() {
+  return (
+    <div className="aura-layer" aria-hidden="true">
+      {ORBS.map((orb, i) => (
+        <div
+          key={i}
+          className="aura-orb"
+          style={{
+            width: orb.size,
+            height: orb.size,
+            top: orb.top,
+            left: orb.left,
+            opacity: orb.opacity,
+            animation: orb.animation,
+            animationDelay: `${i * -7}s`,
+            background: `radial-gradient(circle at 50% 50%, rgb(${orb.hue} / 0.85) 0%, rgb(${orb.hue} / 0.34) 36%, rgb(${orb.hue} / 0) 68%)`,
+          }}
+        />
+      ))}
+
+      {/* Vignette — pulls the field back down at the edges so the chroma
+          always reads as a glow from behind, never as a flat wash. Kept light:
+          crush this and the glass has nothing left to refract. */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(120% 90% at 50% 40%, transparent 0%, rgba(6,6,8,0.2) 60%, rgba(3,3,5,0.72) 100%)',
+        }}
+      />
+    </div>
+  );
+}

--- a/components/ui/ProjectCard.tsx
+++ b/components/ui/ProjectCard.tsx
@@ -9,36 +9,41 @@ interface ProjectCardProps {
   index: number;
 }
 
-// Subtle dark tones — all monochromatic
-const bgTones = [
-  '#111111',
-  '#0e0e0e',
-  '#131313',
-  '#0f0f0f',
-  '#121212',
-  '#141414',
-  '#101010',
-  '#0d0d0d',
-  '#130f0f',
+// Each card gets a slightly different bloom hue so the row reads as a
+// sequence rather than a repeat. All drawn from the same aura palette, and
+// all seen only through glass.
+const BLOOMS = [
+  'var(--aura-indigo)',
+  'var(--aura-violet)',
+  'var(--aura-teal)',
+  'var(--aura-violet)',
+  'var(--aura-indigo)',
+  'var(--aura-teal)',
+  'var(--aura-violet)',
+  'var(--aura-indigo)',
 ];
 
 export function ProjectCard({ project, index }: ProjectCardProps) {
-  const bg = bgTones[index % bgTones.length];
+  const bloom = BLOOMS[index % BLOOMS.length];
   const href = project.appStoreLinks?.apple || project.link;
 
   return (
-    <div className="w-[560px] shrink-0 group cursor-pointer">
-      <a
-        href={href}
-        target={href ? '_blank' : undefined}
-        rel={href ? 'noopener noreferrer' : undefined}
-      >
-        {/* 16:10 image area */}
-        <div
-          className="aspect-[16/10] overflow-hidden mb-8 border border-white/5 relative"
-          style={{ background: bg }}
-        >
-          {/* Logo or ghost first letter */}
+    <a
+      href={href}
+      target={href ? '_blank' : undefined}
+      rel={href ? 'noopener noreferrer' : undefined}
+      className="w-[520px] shrink-0 group block"
+    >
+      <div className="glass glass-sheen glass-interactive p-4">
+        {/* Logo plate */}
+        <div className="relative aspect-[16/10] overflow-hidden rounded-[20px] mb-5 bg-white/[0.03]">
+          <span
+            className="absolute inset-0 pointer-events-none transition-opacity duration-700 opacity-70 group-hover:opacity-100"
+            aria-hidden="true"
+            style={{
+              background: `radial-gradient(80% 70% at 50% 110%, rgb(${bloom} / 0.4) 0%, transparent 70%)`,
+            }}
+          />
           <div className="absolute inset-0 flex items-center justify-center">
             {project.logo ? (
               <Image
@@ -46,50 +51,36 @@ export function ProjectCard({ project, index }: ProjectCardProps) {
                 alt={project.title}
                 width={200}
                 height={80}
-                className="object-contain opacity-70 group-hover:opacity-90 transition-opacity duration-700"
-                style={{ filter: 'none' }}
+                className="object-contain opacity-80 group-hover:opacity-100 transition-all duration-700 group-hover:scale-[1.04]"
               />
             ) : (
               <span
-                className="font-display font-extrabold leading-none tracking-tighter select-none"
-                style={{ fontSize: '10rem', color: 'rgba(255,255,255,0.04)' }}
+                className="font-display font-extrabold leading-none tracking-tight select-none text-white/[0.06]"
+                style={{ fontSize: '9rem' }}
               >
                 {project.title.charAt(0)}
               </span>
             )}
           </div>
-          {/* Hover brightening overlay */}
-          <div className="absolute inset-0 bg-white/0 group-hover:bg-white/[0.04] transition-all duration-700" />
         </div>
 
         {/* Info row */}
-        <div className="flex justify-between items-end border-l border-white/20 pl-6">
+        <div className="flex justify-between items-end px-2 pb-1">
           <div>
-            <h3 className="font-display text-2xl font-extrabold tracking-tighter text-white group-hover:opacity-70 transition-opacity">
-              {project.title.toUpperCase()}
+            <h3 className="font-display text-2xl font-bold tracking-tight text-white">
+              {project.title}
             </h3>
-            <p
-              className="font-display text-[10px] uppercase tracking-widest mt-2"
-              style={{ color: '#919191' }}
-            >
-              {project.technologies.slice(0, 2).join(' / ')}
-            </p>
+            <p className="label mt-1.5">{project.technologies.slice(0, 2).join(' · ')}</p>
           </div>
           {project.comingSoon ? (
-            <span
-              className="font-display text-[9px] uppercase tracking-[0.3em] border border-white/20 px-3 py-1.5 mb-1"
-              style={{ color: '#919191' }}
-            >
-              Soon
-            </span>
+            <span className="label px-3 py-1.5 rounded-full bg-white/[0.06]">Soon</span>
           ) : (
-            <ArrowUpRight
-              className="w-7 h-7 mb-1 transition-opacity duration-300"
-              style={{ color: '#ffffff', opacity: 0.25 }}
-            />
+            <span className="w-10 h-10 rounded-full flex items-center justify-center bg-white/[0.06] transition-all duration-500 group-hover:bg-white group-hover:scale-105">
+              <ArrowUpRight className="w-4 h-4 text-white transition-colors duration-500 group-hover:text-black" />
+            </span>
           )}
         </div>
-      </a>
-    </div>
+      </div>
+    </a>
   );
 }

--- a/components/ui/RevealText.tsx
+++ b/components/ui/RevealText.tsx
@@ -46,28 +46,25 @@ function ScrollRevealWord({
   );
 }
 
-export function RevealText(props: RevealTextProps) {
+function ScrollReveal({ children, className, scrollProgress }: RevealTextScrollProps) {
+  const words = children.split(' ');
+  return (
+    <span className={className}>
+      {words.map((word, index) => (
+        <ScrollRevealWord
+          key={index}
+          word={word}
+          index={index}
+          total={words.length}
+          scrollProgress={scrollProgress}
+        />
+      ))}
+    </span>
+  );
+}
+
+function ViewportReveal({ children, className = '', delay = 0 }: RevealTextViewportProps) {
   const ref = useRef(null);
-
-  if (props.mode === 'scroll') {
-    const words = props.children.split(' ');
-    return (
-      <span className={props.className}>
-        {words.map((word, index) => (
-          <ScrollRevealWord
-            key={index}
-            word={word}
-            index={index}
-            total={words.length}
-            scrollProgress={props.scrollProgress}
-          />
-        ))}
-      </span>
-    );
-  }
-
-  // Viewport mode (default)
-  const { children, className = '', delay = 0 } = props as RevealTextViewportProps;
   const isInView = useInView(ref, { once: true, margin: '-10%' });
   const words = children.split(' ');
 
@@ -92,4 +89,14 @@ export function RevealText(props: RevealTextProps) {
       ))}
     </span>
   );
+}
+
+/**
+ * The two modes are separate components rather than branches in one, because
+ * the viewport mode calls `useInView` and the scroll mode returns before it.
+ * Switching `mode` on a mounted instance would change the hook order and
+ * throw \u2014 splitting them means each renders a fresh component instead.
+ */
+export function RevealText(props: RevealTextProps) {
+  return props.mode === 'scroll' ? <ScrollReveal {...props} /> : <ViewportReveal {...props} />;
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,14 +1,25 @@
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { FlatCompat } from '@eslint/eslintrc';
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
+import nextTypeScript from 'eslint-config-next/typescript';
+import prettier from 'eslint-config-prettier';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier')];
+/**
+ * eslint-config-next 16 ships native flat configs, so they are imported
+ * directly. Routing them through `FlatCompat` — which is what this file used
+ * to do — makes eslintrc try to validate an already-flat config and blow up
+ * with "Converting circular structure to JSON" before a single source file is
+ * read.
+ *
+ * `prettier` goes last: it only turns off rules that would fight the
+ * formatter. Formatting itself stays in the `format` / `format:check`
+ * scripts rather than running through ESLint.
+ */
+const eslintConfig = [
+  {
+    ignores: ['.next/**', 'out/**', 'build/**', 'next-env.d.ts', 'tasks/**'],
+  },
+  ...nextCoreWebVitals,
+  ...nextTypeScript,
+  prettier,
+];
 
 export default eslintConfig;

--- a/lib/hooks/useGlassLens.ts
+++ b/lib/hooks/useGlassLens.ts
@@ -1,0 +1,418 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+import { Renderer, Program, Mesh, Triangle, Texture } from 'ogl';
+
+/**
+ * Drives the hero's refracting glass lens.
+ *
+ * The headline is rasterised into a texture from the *measured* DOM line
+ * boxes, so the canvas type is a pixel-accurate stand-in for the real `<h1>`
+ * at any viewport size and font weight. The `<h1>` itself stays in the
+ * document — it is only visually hidden once WebGL is confirmed working, so
+ * search engines, screen readers and no-WebGL browsers all still get real
+ * text.
+ *
+ * Hiding it is done by writing to the node directly rather than through React
+ * state: the heading is an external thing this effect is synchronising with,
+ * and doing it here swaps canvas-in for heading-out within a single frame, so
+ * there is no window in which both or neither are painted.
+ */
+
+const VERTEX = /* glsl */ `
+  attribute vec2 uv;
+  attribute vec2 position;
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+`;
+
+const FRAGMENT = /* glsl */ `
+  precision highp float;
+
+  uniform sampler2D tMap;
+  uniform vec2 uLens;      // lens centre, uv space
+  uniform float uRadius;   // lens radius, in units of viewport height
+  uniform float uAspect;   // width / height
+  uniform float uMagnify;
+  uniform float uRefract;
+  uniform float uChroma;
+  uniform float uActive;   // lens fade-in
+  uniform float uReveal;   // entrance 0 -> 1
+
+  varying vec2 vUv;
+
+  // Alpha of the type at a point, zero outside the texture so the lens never
+  // smears edge pixels when it drifts past a border.
+  float sampleA(vec2 uv) {
+    vec2 inb = step(vec2(0.0), uv) * step(uv, vec2(1.0));
+    return texture2D(tMap, uv).a * inb.x * inb.y;
+  }
+
+  void main() {
+    // Entrance: the type rises into place and converges out of an RGB-split
+    // ghost — the same optics as the lens, applied to the whole field.
+    float rev = uReveal;
+    vec2 uv = vUv - vec2(0.0, (1.0 - rev) * 0.055);
+    vec2 e = vec2((1.0 - rev) * 0.03, 0.0);
+
+    vec2 p = (uv - uLens) * vec2(uAspect, 1.0);
+    float d = length(p);
+    float r = d / max(uRadius, 1e-4);
+    vec2 dir = d > 1e-5 ? p / d : vec2(0.0);
+    vec2 aspectFix = vec2(1.0 / uAspect, 1.0);
+
+    // --- Outside the glass ---
+    float pR = sampleA(uv + e);
+    float pG = sampleA(uv);
+    float pB = sampleA(uv - e);
+    vec3 plainRgb = vec3(pR, pG, pB);
+    float plainA = max(pR, max(pG, pB));
+
+    // --- Under the glass ---
+    // A liquid-glass slab, not a crystal ball. The middle is flat and evenly
+    // magnified, the way a thick pane behaves, and all of the bending is
+    // compressed into a band at the rim. Putting the distortion at the centre
+    // instead is what makes these effects read as a glass sphere.
+    float rc = min(r, 1.0);
+    vec2 base = uLens + (uv - uLens) * (1.0 - uMagnify);
+
+    float edge = smoothstep(0.40, 1.0, rc);
+    float rim = edge * edge;
+    vec2 dirFix = dir * aspectFix;
+    vec2 suv = base + dirFix * rim * uRefract;
+    vec2 ca = dirFix * rim * uChroma + e;
+
+    float gR = sampleA(suv + ca);
+    float gG = sampleA(suv);
+    float gB = sampleA(suv - ca);
+    vec3 glassRgb = vec3(gR, gG, gB) * 1.12;
+    float glassA = max(gR, max(gG, gB));
+
+    // Specular rim, brightest where a key light up and to the left would hit.
+    float ring = smoothstep(0.90, 0.982, r) - smoothstep(0.982, 1.0, r);
+    float key = 0.5 + 0.5 * dot(dir, normalize(vec2(-0.55, 0.83)));
+    float spec = ring * (0.18 + 0.82 * key * key);
+
+    // Flat body tint so the disc reads as an object rather than a hole.
+    float body = (1.0 - edge * 0.45) * 0.03;
+
+    glassRgb += spec * 0.85 + body;
+    glassA = max(glassA, max(spec * 0.8, body));
+
+    float inside = (1.0 - smoothstep(0.985, 1.0, r)) * uActive;
+    vec3 rgb = mix(plainRgb, glassRgb, inside);
+    float a = mix(plainA, glassA, inside);
+
+    // Premultiplied output — additive highlights compose correctly.
+    gl_FragColor = vec4(rgb * rev, a * rev);
+  }
+`;
+
+const IDLE_AFTER_MS = 2200;
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export function useGlassLens(
+  hostRef: RefObject<HTMLDivElement | null>,
+  titleRef: RefObject<HTMLElement | null>,
+  discRef: RefObject<HTMLDivElement | null>
+) {
+  useEffect(() => {
+    const host = hostRef.current;
+    const title = titleRef.current;
+    if (!host || !title || prefersReducedMotion()) return;
+
+    let renderer: Renderer;
+    try {
+      renderer = new Renderer({
+        alpha: true,
+        premultipliedAlpha: true,
+        antialias: false,
+        dpr: Math.min(window.devicePixelRatio || 1, 2),
+      });
+    } catch {
+      return; // No WebGL — the plain <h1> stays visible.
+    }
+
+    const gl = renderer.gl;
+    const canvas = gl.canvas as HTMLCanvasElement;
+    canvas.style.position = 'absolute';
+    canvas.style.inset = '0';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.style.pointerEvents = 'none';
+    canvas.style.zIndex = '30'; // above .lens-disc
+    host.appendChild(canvas);
+
+    // Offscreen 2D surface the headline is rasterised onto.
+    const textCanvas = document.createElement('canvas');
+    const ctx = textCanvas.getContext('2d');
+    if (!ctx) return;
+
+    const texture = new Texture(gl, {
+      image: textCanvas,
+      generateMipmaps: false,
+      minFilter: gl.LINEAR,
+      magFilter: gl.LINEAR,
+    });
+
+    const program = new Program(gl, {
+      vertex: VERTEX,
+      fragment: FRAGMENT,
+      transparent: true,
+      uniforms: {
+        tMap: { value: texture },
+        uLens: { value: [0.5, 0.5] },
+        uRadius: { value: 0.2 },
+        uAspect: { value: 1 },
+        uMagnify: { value: 0.24 },
+        uRefract: { value: 0.075 },
+        uChroma: { value: 0.014 },
+        uActive: { value: 0 },
+        uReveal: { value: 0 },
+      },
+    });
+
+    const mesh = new Mesh(gl, { geometry: new Triangle(gl), program });
+
+    let width = 0;
+    let height = 0;
+    let radiusPx = 140;
+
+    /** Rasterise the headline from its measured DOM boxes. */
+    function paint() {
+      if (!ctx) return;
+      const hostRect = host!.getBoundingClientRect();
+      const dpr = renderer.dpr;
+      width = hostRect.width;
+      height = hostRect.height;
+      if (width < 2 || height < 2) return;
+
+      textCanvas.width = Math.round(width * dpr);
+      textCanvas.height = Math.round(height * dpr);
+
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, textCanvas.width, textCanvas.height);
+      ctx.scale(dpr, dpr);
+
+      const lines = title!.querySelectorAll<HTMLElement>('[data-lens-line]');
+      lines.forEach((line) => {
+        const rect = line.getBoundingClientRect();
+        const cs = getComputedStyle(line);
+        const text = (line.textContent ?? '').trim();
+        if (!text || rect.width < 1) return;
+
+        const fontSize = parseFloat(cs.fontSize);
+        const lineHeight = parseFloat(cs.lineHeight) || fontSize * 1.2;
+        ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${fontSize}px ${cs.fontFamily}`;
+        if ('letterSpacing' in ctx) {
+          (ctx as CanvasRenderingContext2D & { letterSpacing: string }).letterSpacing =
+            cs.letterSpacing;
+        }
+
+        const m = ctx.measureText(text);
+        const ascent = m.fontBoundingBoxAscent || m.actualBoundingBoxAscent || fontSize * 0.8;
+        const descent = m.fontBoundingBoxDescent || m.actualBoundingBoxDescent || fontSize * 0.2;
+        const halfLeading = (lineHeight - (ascent + descent)) / 2;
+
+        const x = rect.left - hostRect.left;
+        const y = rect.top - hostRect.top + halfLeading + ascent;
+
+        // Match the DOM box width exactly. Canvas letter-spacing support is
+        // uneven, and the webfont may still be swapping in — squeezing to the
+        // measured box keeps the two in register either way.
+        const scale = m.width > 0 ? Math.min(1.6, Math.max(0.6, rect.width / m.width)) : 1;
+
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.scale(scale, 1);
+        if (line.dataset.lensOutline !== undefined) {
+          ctx.lineWidth = Math.max(1, fontSize * 0.014);
+          ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+          ctx.strokeText(text, 0, 0);
+        } else {
+          ctx.fillStyle = '#ffffff';
+          ctx.fillText(text, 0, 0);
+        }
+        ctx.restore();
+      });
+
+      texture.image = textCanvas;
+      texture.needsUpdate = true;
+    }
+
+    function resize() {
+      const rect = host!.getBoundingClientRect();
+      if (rect.width < 2 || rect.height < 2) return;
+      renderer.setSize(rect.width, rect.height);
+      radiusPx = Math.max(78, Math.min(148, Math.min(rect.width, rect.height) * 0.14));
+      program.uniforms.uAspect.value = rect.width / rect.height;
+      program.uniforms.uRadius.value = radiusPx / rect.height;
+      if (discRef.current) {
+        discRef.current.style.width = `${radiusPx * 2}px`;
+        discRef.current.style.height = `${radiusPx * 2}px`;
+      }
+      paint();
+    }
+
+    // --- Motion state -------------------------------------------------
+    // Coordinates are "from the top" here and flipped on upload.
+    const pointer = { x: 0.42, y: 0.45 };
+    const current = { x: 0.42, y: 0.45 };
+    let lastMove = 0;
+    let idleWeight = 1; // starts idle — the lens drifts until you touch it
+    let start = 0;
+    let raf = 0;
+    let disposed = false;
+
+    function onPointerMove(e: PointerEvent) {
+      const rect = host!.getBoundingClientRect();
+      if (rect.width < 2) return;
+      pointer.x = Math.max(-0.15, Math.min(1.15, (e.clientX - rect.left) / rect.width));
+      pointer.y = Math.max(-0.15, Math.min(1.15, (e.clientY - rect.top) / rect.height));
+      lastMove = performance.now();
+    }
+
+    // --- Device tilt ----------------------------------------------------
+    // Feeds the same `pointer` target as the mouse, so the smoothing, idle
+    // handover and clamping are all shared.
+    //
+    // The first reading becomes the neutral point rather than assuming a
+    // posture: people hold phones anywhere from flat on a table to near
+    // vertical, and an absolute mapping puts the lens hard against an edge
+    // for most of them.
+    let tiltOrigin: { beta: number; gamma: number } | null = null;
+
+    function onOrientation(e: DeviceOrientationEvent) {
+      const { beta, gamma } = e;
+      if (beta === null || gamma === null) return;
+      if (!tiltOrigin) {
+        tiltOrigin = { beta, gamma };
+        return;
+      }
+      // A firm ~32° tilt takes the lens most of the way to an edge. Tighter
+      // than that and small hand tremor throws it across the screen.
+      const dx = (gamma - tiltOrigin.gamma) / 32;
+      const dy = (beta - tiltOrigin.beta) / 32;
+      pointer.x = Math.max(-0.1, Math.min(1.1, 0.5 + dx * 0.55));
+      pointer.y = Math.max(-0.1, Math.min(1.1, 0.5 + dy * 0.55));
+      lastMove = performance.now();
+    }
+
+    type PermissionCapableDOE = typeof DeviceOrientationEvent & {
+      requestPermission?: () => Promise<'granted' | 'denied'>;
+    };
+
+    function enableTilt() {
+      window.addEventListener('deviceorientation', onOrientation, { passive: true });
+    }
+
+    // Touch devices only. Some laptops and 2-in-1s expose an accelerometer,
+    // and there tilt would fight the mouse for the same target.
+    const wantsTilt =
+      window.matchMedia('(pointer: coarse)').matches &&
+      typeof DeviceOrientationEvent !== 'undefined';
+    const DOE = wantsTilt ? (DeviceOrientationEvent as PermissionCapableDOE) : null;
+    const needsTiltPermission = typeof DOE?.requestPermission === 'function';
+
+    // iOS 13+ only grants motion access from inside a user gesture. Rather
+    // than prompting on arrival, wait for the first deliberate touch on the
+    // hero — the request then has visible context, and declining just leaves
+    // the lens drifting with nothing else broken.
+    function onFirstTouch() {
+      DOE!.requestPermission!()
+        .then((state) => {
+          if (!disposed && state === 'granted') enableTilt();
+        })
+        .catch(() => {
+          /* declined or unavailable — drift is the fallback */
+        });
+    }
+
+    if (needsTiltPermission) {
+      host.addEventListener('touchend', onFirstTouch, { passive: true, once: true });
+    } else if (DOE) {
+      // Android and anything else with a sensor: no permission gate.
+      enableTilt();
+    }
+
+    function frame(now: number) {
+      if (disposed) return;
+      if (!start) start = now;
+      const t = now - start;
+
+      // Entrance
+      const revT = Math.min(1, t / 1500);
+      const reveal = 1 - Math.pow(1 - revT, 4);
+      program.uniforms.uReveal.value = reveal;
+
+      // The lens only appears once the type has settled.
+      const actT = Math.max(0, Math.min(1, (t - 850) / 900));
+      program.uniforms.uActive.value = actT * actT * (3 - 2 * actT);
+
+      // Drift when the pointer has been still, follow it when it moves.
+      // Asymmetric on purpose: grabbing the lens has to feel immediate, while
+      // handing it back to its own path should be slow enough not to register
+      // as the lens "leaving".
+      const idle = now - lastMove > IDLE_AFTER_MS;
+      idleWeight += ((idle ? 1 : 0) - idleWeight) * (idle ? 0.006 : 0.14);
+
+      const driftX = 0.5 + 0.3 * Math.sin(now * 0.00027) + 0.06 * Math.sin(now * 0.00071);
+      const driftY = 0.5 + 0.22 * Math.sin(now * 0.00041 + 1.3);
+
+      const tx = pointer.x + (driftX - pointer.x) * idleWeight;
+      const ty = pointer.y + (driftY - pointer.y) * idleWeight;
+
+      current.x += (tx - current.x) * 0.12;
+      current.y += (ty - current.y) * 0.12;
+
+      program.uniforms.uLens.value = [current.x, 1 - current.y];
+
+      if (discRef.current && width > 0) {
+        discRef.current.style.transform = `translate3d(${current.x * width - radiusPx}px, ${
+          current.y * height - radiusPx
+        }px, 0)`;
+        discRef.current.style.opacity = String(program.uniforms.uActive.value * 0.9);
+      }
+
+      renderer.render({ scene: mesh });
+      raf = requestAnimationFrame(frame);
+    }
+
+    resize();
+    // The canvas is now drawing the headline, so hand it over. See
+    // .lens-handoff in globals.css — this suppresses paint only, keeping the
+    // heading in layout and in the accessibility tree.
+    title.classList.add('lens-handoff');
+    raf = requestAnimationFrame(frame);
+
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(host);
+
+    // The headline is measured, so it has to be re-measured once the webfont
+    // actually lands.
+    if (document.fonts?.ready) void document.fonts.ready.then(() => !disposed && resize());
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('deviceorientation', onOrientation);
+      host.removeEventListener('touchend', onFirstTouch);
+      ro.disconnect();
+      canvas.remove();
+      title.classList.remove('lens-handoff');
+      const ext = gl.getExtension('WEBGL_lose_context');
+      ext?.loseContext();
+    };
+  }, [hostRef, titleRef, discRef]);
+}

--- a/lib/hooks/useNavigation.ts
+++ b/lib/hooks/useNavigation.ts
@@ -30,6 +30,9 @@ export function useNavigation(navItems: NavItem[]) {
 
   useEffect(() => {
     const sectionOrder = navItems.map((item) => item.id);
+    // Captured once so the cleanup clears the same Set this effect observed
+    // into, not whatever `.current` happens to point at by teardown.
+    const intersecting = intersectingRef.current;
 
     const observerOptions = {
       root: null,
@@ -40,16 +43,16 @@ export function useNavigation(navItems: NavItem[]) {
     const observerCallback = (entries: IntersectionObserverEntry[]) => {
       for (const entry of entries) {
         if (entry.isIntersecting) {
-          intersectingRef.current.add(entry.target.id);
+          intersecting.add(entry.target.id);
         } else {
-          intersectingRef.current.delete(entry.target.id);
+          intersecting.delete(entry.target.id);
         }
       }
 
       // Pick the furthest-down intersecting section
       let active = '';
       for (const id of sectionOrder) {
-        if (intersectingRef.current.has(id)) {
+        if (intersecting.has(id)) {
           active = id;
         }
       }
@@ -81,7 +84,7 @@ export function useNavigation(navItems: NavItem[]) {
     return () => {
       observer.disconnect();
       window.removeEventListener('scroll', handleScroll);
-      intersectingRef.current.clear();
+      intersecting.clear();
     };
   }, [navItems]);
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
Rethinks the site's visual language from architectural brutalism to a soft, refractive glass system. **All copy is byte-for-byte identical** — only casing changes, and the `01 //` / `02 //` / `03 //` section numbering is dropped as part of the type reset.

## The load-bearing idea

`backdrop-filter` over a flat background produces *nothing*. Glass is a refractive material; it needs something behind it to bend and tint, or it renders as grey rectangles. So the ambient light field is structural, not decorative — every glass surface on the page depends on it existing.

Colour only ever appears *through* glass. All type and UI stay monochrome.

## Hero

A cursor-tracked WebGL lens using `ogl`, which was already in `package.json` and completely unused. Three layers: the ambient field, a DOM disc whose `backdrop-filter` bends the field and the copy behind it, and a canvas rendering the headline with rim refraction, chromatic aberration and a specular highlight.

The lens is modelled as a **flat slab** — uniform magnification through the middle, all bending compressed into the rim. My first pass put peak magnification at the centre, which is sphere optics and read unmistakably as a crystal ball.

The headline texture is rasterised from the **measured DOM line boxes**, so canvas type tracks the real `<h1>` at any viewport size or font weight. The `<h1>` stays in the document and is only paint-suppressed once WebGL is confirmed working.

Tilt input on touch devices calibrates on the first reading rather than mapping absolutely — people hold phones anywhere from flat to near-vertical, and an absolute mapping pins the lens to an edge for most postures.

## Fixes to existing behaviour

- **The navbar rendered white-on-white over the contact section.** It floats over both halves of the site, so it now flips material when contact passes beneath it.
- **`eslint.config.mjs` has been crashing on load**, so linting was entirely non-functional. It routed configs through `FlatCompat`, but `eslint-config-next` 16 already ships native flat configs. Fixed, plus `next lint` → `eslint .` (the former was removed in Next 16).
- Two genuine bugs that lint caught the moment it ran: `RevealText` called `useInView` after an early return (rules-of-hooks violation that throws if `mode` changes on a mounted instance), and `useNavigation` read a ref in effect cleanup instead of a captured local.

## Verification

- `npm run lint`, `npx tsc --noEmit`, `npm run build` — all exit 0.
- Screenshotted at 1512×950 and 390×844 across hero, about, projects, contact, footer.
- Reduced motion: no canvas created, `<h1>` renders as ordinary text.
- Accessibility tree while the canvas is drawing reports `heading lvl=1 "Jack Knoell Dev."` — the heading stays exposed.
- Simulated `deviceorientation` events move the lens as expected.
- No console errors on any route.

## Worth knowing

**Lightning CSS silently drops any rule containing the `-webkit-text-stroke` shorthand.** No warning — the entire declaration block vanishes from the compiled stylesheet. The longhands survive. This broke the outlined "Dev." mid-build and only surfaced by diffing the served CSS against source. Noted in a comment next to the rule.

## Not covered

- The **iOS motion-permission path is untested on a real device.** Headless Chrome can't exercise `DeviceOrientationEvent.requestPermission`. The request is deferred to the first touch on the hero so it has visible context, and declining leaves the drift path running — but that flow deserves a real-iPhone check before merge.
- Aura intensity is a judgment call I made from screenshots. Easier to assess on a real display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)