### PR TITLE
Point the footer GitHub link at knoelljack

### DIFF
--- a/components/sections/Footer.tsx
+++ b/components/sections/Footer.tsx
@@ -1,5 +1,5 @@
 const ELSEWHERE = [
-  { label: 'GitHub', href: 'https://github.com/jack-at-alice' },
+  { label: 'GitHub', href: 'https://github.com/knoelljack' },
   { label: 'LinkedIn', href: 'https://www.linkedin.com/in/jackknoell/' },
   { label: 'Resume', href: '/resume.pdf' },
 ];


### PR DESCRIPTION
The footer still linked to `github.com/jack-at-alice`, carried over from the previous design. Points at the personal profile instead.