### PR TITLE
Retitle the work section without a project count

### DIFF
--- a/components/sections/WorkSection.tsx
+++ b/components/sections/WorkSection.tsx
@@ -183,7 +183,7 @@ export function WorkSection() {
           <div>
             <p className="mono">Selected work</p>
             <h2 className="display t-section mt-4">
-              Seven brands, <em>one build.</em>
+              Brands I&rsquo;ve <em>built for.</em>
             </h2>
           </div>
 


### PR DESCRIPTION
"Seven brands, one build" implied the seven projects shared a single build, which isn't true — they were separate projects on different stacks. It also pinned a count into the heading that has to change whenever the project list does.

Now reads **Brands I've *built for.*** — no count, no claim about how they were built, and it still carries the italic accent that matches the About and Contact headings.

The carousel's `01 / 07` position indicator is unchanged; it derives from the array and updates itself.